### PR TITLE
Define printable representations of ADTs

### DIFF
--- a/src/coalton.lisp
+++ b/src/coalton.lisp
@@ -269,7 +269,16 @@
                                 ;; XXX: For now, we just store a vector.
                                 ((value :initarg :value
                                         :type simple-vector))
-                                (:metaclass final-class)))))
+                                (:metaclass final-class))))
+              :collect (ecase kind
+                         (:variable
+                          `(defmethod print-object ((self ,name) stream)
+                             (format stream "#.~s" ',name)))
+                         (:function
+                          `(defmethod print-object ((self ,name) stream)
+                             (format stream "#.(~s ~{~s~^ ~})"
+                                     ',name
+                                     (coerce (slot-value self 'value) 'list))))))
 
          ;; Define constructors
          ,@(loop :for (kind name ty) :in ctors

--- a/src/coalton.lisp
+++ b/src/coalton.lisp
@@ -276,7 +276,7 @@
                              (format stream "#.~s" ',name)))
                          (:function
                           `(defmethod print-object ((self ,name) stream)
-                             (format stream "#.(~s ~{~s~^ ~})"
+                             (format stream "#.(~s~{ ~s~})"
                                      ',name
                                      (coerce (slot-value self 'value) 'list))))))
 

--- a/src/library.lisp
+++ b/src/library.lisp
@@ -1,6 +1,6 @@
 ;;; library.lisp
 
-(in-package #:coalton-user)
+(cl:in-package #:coalton-user)
 
 (coalton
   (define-type Void)


### PR DESCRIPTION
The first change defines a PRINT-OBJECT method for the the cases of an ADT.  The other one is a minor change to make recompiling the file more convenient.