### PR TITLE
Make define-type forms work at load-time

### DIFF
--- a/src/toplevel-define-type.lisp
+++ b/src/toplevel-define-type.lisp
@@ -101,6 +101,15 @@ where
     ;; TODO: Structs? Vectors? Classes? This should be thought
     ;; about. Let's start with classes.
     `(progn
+       (unless (tycon-knownp ',tycon-name)
+         (setf (find-tycon ',tycon-name) ,tycon))
+
+       ,@(loop :for (_ name ty) :in ctors
+               :collect `(unless (var-knownp ',name)
+                             (forward-declare-variable ',name))
+               :collect `(unless (entry-declared-type (var-info ',name))
+                           (setf (var-declared-type ',name) ,ty)))
+
        ;; Define types. Create the superclass.
        ;;
        ;; TODO: handle special case of 1 ctor.

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -17,6 +17,12 @@
   ;; nice to make it read-only though.
   (constructors nil      :type alexandria:proper-list))
 
+(defmethod make-load-form ((tycon tycon) &optional environment)
+  (declare (ignore environment))
+  `(make-tycon :name ',(tycon-name tycon)
+               :arity ,(tycon-arity tycon)
+               :constructors ',(tycon-constructors tycon)))
+
 ;;; TODO: figure out type aliases.
 (define-global-var **type-definitions** (make-hash-table :test 'eql)
   "Database of Coalton type definitions. These are mappings from symbols to type constructors.")
@@ -57,11 +63,21 @@
   (instance nil :type (or null ty)     :read-only nil)
   (name     nil :type (or null symbol) :read-only nil))
 
+(defmethod make-load-form ((tyvar tyvar) &optional environment)
+  (declare (ignore environment))
+  `(%make-tyvar :id ,(tyvar-id tyvar)
+                :instance ,(tyvar-instance tyvar)
+                :name ',(tyvar-name tyvar)))
+
 (defstruct (tyapp (:include ty)
                   (:constructor tyapp (constructor &rest types)))
   "A type application. (Note that this could be the application of a 0-arity constructor.)"
   (constructor  nil :type tycon     :read-only t)
   (types        nil :type type-list :read-only t))
+
+(defmethod make-load-form ((tyapp tyapp) &optional environment)
+  (declare (ignore environment))
+  `(tyapp ,(tyapp-constructor tyapp) ,@(tyapp-types tyapp)))
 
 (defun tyapp-name (tyapp)
   (tycon-name (tyapp-constructor tyapp)))
@@ -73,6 +89,10 @@
   "A function type."
   (from nil :type type-list :read-only t)
   (to   nil :type ty        :read-only t))
+
+(defmethod make-load-form ((tyfun tyfun) &optional environment)
+  (declare (ignore environment))
+  `(tyfun (list ,@(tyfun-from tyfun)) ,(tyfun-to tyfun)))
 
 (defun tyfun-arity (tyfun)
   (length (tyfun-from tyfun)))


### PR DESCRIPTION
PROOF-OF-CONCEPT
GAWDAWFUL HACKS
DO NOT MERGE

Fixes #11

This is a quick-and-dirty proof-of-concept fix for the issue I described in #11. This contains some fugly hacks, like the smattering 'round of `make-load-form`s rather than just doing the macro expansion properly, and also the fact that it's essentially duplicating code. Possibly everything could just be pushed down into the macro expansion and wrapped in `(eval-when (:compile-toplevel :load-toplevel)...)` or some such, but I wasn't sure if the registering of `tycons` also needed to happen at macro-expansion time (as distinct from compile-time).