### PR TITLE
Add tuple support

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -13,6 +13,7 @@
    #:define-type)
   (:export
    #:->
+   #:*
    #:void
    #:integer
    #:string
@@ -58,6 +59,8 @@
    #:type-mismatch-types                ; READER
    #:arity-mismatch                     ; CONDITION
    #:arity-mismatch-arities             ; READER
+   #:tuple-size-mismatch                ; CONDITION
+   #:tuple-size-mismatch-sizes          ; READER
    #:non-terminating-unification-error  ; CONDITION
    #:non-terminating-unification-error-contained-type
                                         ; READER


### PR DESCRIPTION
This is a PR to add tuple support to Coalton. Refer to #15. Here are the TODOs:

- [x] Add type syntax for tuples (parsing and unparsing). Proposal: `(* t1 t2 ... tn)`
- [x] Allow tuples to be type checked and unified.
- [ ] Decide how tuple values are compiled into Lisp. Proposal: `simple-vector`
- [ ] Add syntax for tuple construction. Proposal: not sure
- [ ] Add depth-1 pattern matching.

I'm not sure about this one, but...

- [ ] Add syntax for tuple projection. (Note that this can't be a generic function taking a generic integer argument. The syntax would have to be special, like `(@ <integer> <expr>)` e.g. `(@ 15 v)` which verifies that the value `v` is a 15-or-fewer tuple.) This might be hard to type check.