### PR TITLE
allow (DEFINE-TYPE A A)

### DIFF
--- a/src/early-types.lisp
+++ b/src/early-types.lisp
@@ -34,16 +34,16 @@
 
 (define-type-constructor coalton:unit 0)
 (define-global-var* unit-type (tyapp (find-tycon 'coalton:unit)))
-(forward-declare-variable 'coalton:Singleton unit-type)
+(forward-declare-variable 'coalton:Unit unit-type)
 
-;; (macroexpand-1 `(coalton:coalton
+;; (macroexpand-1 `(coalton:coalton-toplevel
 ;;                   (coalton:define-type Unit
-;;                     Singleton)))
+;;                     Unit)))
 
-(DEFCLASS COALTON:UNIT NIL NIL
+(DEFCLASS COALTON:UNIT () ()
   (:METACLASS ABSTRACT-CLASS))
-(DEFCLASS COALTON:SINGLETON (COALTON:UNIT) NIL
+(DEFCLASS COALTON::UNIT/UNIT (COALTON:UNIT) ()
   (:METACLASS SINGLETON-CLASS))
-(DEFMETHOD PRINT-OBJECT ((SELF COALTON:SINGLETON) STREAM)
-  (FORMAT STREAM "#.~s" 'COALTON:SINGLETON))
-(GLOBAL-VARS:DEFINE-GLOBAL-VAR* COALTON:SINGLETON (MAKE-INSTANCE 'COALTON:SINGLETON))
+(DEFMETHOD PRINT-OBJECT ((SELF COALTON::UNIT/UNIT) STREAM)
+  (FORMAT STREAM "#.~s" 'COALTON:UNIT))
+(GLOBAL-VARS:DEFINE-GLOBAL-VAR* COALTON:UNIT (MAKE-INSTANCE 'COALTON::UNIT/UNIT))

--- a/src/library.lisp
+++ b/src/library.lisp
@@ -6,7 +6,7 @@
   ;; Defined in early-types.lisp
   #+ignore
   (define-type Unit
-    Singleton)
+    Unit)
 
   (define-type coalton:Boolean
     coalton:True
@@ -59,7 +59,7 @@
 
 ;;; Combinators
 (coalton-toplevel
-  (define (ignore x)     Singleton)
+  (define (ignore x)     Unit)
   (define (identity x)   x)
   (define (constantly x) (fn (y) x))
   (define (flip f)       (fn (x y) (f y x)))
@@ -129,15 +129,15 @@
 
 ;;; Mutable Cells
 (coalton-toplevel
-  (define-type (Mutable-Cell t)
+  (define-type (Ref t)
     (Ref t))
 
-  (declare mutate-cell (-> ((Mutable-Cell t) t) Unit))
+  (declare mutate-cell (-> ((Ref t) t) Unit))
   (define (mutate-cell r v)
     (lisp Unit
       (cl:progn
         (cl:setf (cl:svref (cl:slot-value r 'coalton-impl::value) 0) v)
-        Singleton))))
+        Unit))))
 
 (coalton-toplevel
   (define (gcd u v)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -17,7 +17,7 @@
    #:integer
    #:string
    #:boolean #:true #:false
-   #:unit #:singleton)
+   #:unit)
   (:export
    #:declare
    #:fn

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -7,6 +7,9 @@
 (defstruct tycon
   "A constructor for type applications."
   ;; The name of the TYCON. Technically this is only used for printing!
+  ;;
+  ;; We also incidentally rely on this in COMPILE-VALUE so that we can
+  ;; construct a constructor's class name.
   (name (required 'name) :type symbol                 :read-only t)
   ;; Was this tycon redefined in the global database, so the above
   ;; name no longer makes sense?


### PR DESCRIPTION
This commit refactors how values are compiled. In particular,
something like (DEFINE-TYPE A C1 C2 ... Cn) is compiled as

    (DEFCLASS A ())
    (DEFCLASS A/C1 (A))
    ...
    (DEFCLASS A/Cn (A))

It's not the most mathematically elegant (it "pollutes"), but it seems
like a practical trade-off.

This fixes issue #9.