### PR TITLE
Don't warn when overriding equal type

### DIFF
--- a/src/global-environment.lisp
+++ b/src/global-environment.lisp
@@ -65,12 +65,12 @@
   (check-type new-value ty)
   (let ((info (var-info var)))
     (alexandria:when-let ((existing-declared-type (entry-declared-type info)))
-      (if (type= existing-declared-type new-value)
-          (return-from var-declared-type var)
-          (style-warn "Overwriting declared type of ~S from ~A to ~A"
-                      var
-                      (unparse-type existing-declared-type)
-                      (unparse-type new-value))))
+      (when (type= existing-declared-type new-value)
+        (return-from var-declared-type var))
+      (style-warn "Overwriting declared type of ~S from ~A to ~A"
+                  var
+                  (unparse-type existing-declared-type)
+                  (unparse-type new-value)))
     (alexandria:when-let ((derived (var-derived-type var)))
       (unless (more-or-equally-specific-type-p derived new-value)
         (error "Cannot declare ~S as ~S because that is ~
@@ -88,12 +88,12 @@
   (check-type new-value ty)
   (let ((info (var-info var)))
     (alexandria:when-let ((existing-derived-type (entry-derived-type info)))
-      (if (type= existing-derived-type new-value)
-          (return-from var-derived-type var)
-          (style-warn "Overwriting derived type of ~S from ~A to ~A"
-                      var
-                      (unparse-type existing-derived-type)
-                      (unparse-type new-value))))
+      (when (type= existing-derived-type new-value)
+        (return-from var-derived-type var))
+      (style-warn "Overwriting derived type of ~S from ~A to ~A"
+                  var
+                  (unparse-type existing-derived-type)
+                  (unparse-type new-value)))
     (alexandria:when-let ((declared (var-declared-type var)))
       (unless (more-or-equally-specific-type-p new-value declared)
         (error "The derived type of ~S, which is ~S, is incompatible ~

--- a/src/global-environment.lisp
+++ b/src/global-environment.lisp
@@ -64,8 +64,13 @@
 (defun (setf var-declared-type) (new-value var)
   (check-type new-value ty)
   (let ((info (var-info var)))
-    (when (entry-declared-type info)
-      (style-warn "Overwriting declared type of ~S" var))
+    (let ((existing-declared-type (entry-declared-type info)))
+      (when (and existing-declared-type
+                 (not (type= existing-declared-type new-value)))
+        (style-warn "Overwriting declared type of ~S from ~A to ~A"
+                    var
+                    (unparse-type existing-declared-type)
+                    (unparse-type new-value))))
     (alexandria:when-let ((derived (var-derived-type var)))
       (unless (more-or-equally-specific-type-p derived new-value)
         (error "Cannot declare ~S as ~S because that is ~
@@ -82,9 +87,15 @@
 (defun (setf var-derived-type) (new-value var)
   (check-type new-value ty)
   (let ((info (var-info var)))
-    (when (entry-derived-type info)
-      (style-warn "Overwriting derived type of ~S" var))
+    (let ((existing-derived-type (entry-derived-type info)))
+      (when (and existing-derived-type
+                 (not (type= existing-derived-type new-value)))
+        (style-warn "Overwriting derived type of ~S from ~A to ~A"
+                    var
+                    (unparse-type existing-derived-type)
+                    (unparse-type new-value))))
     (alexandria:when-let ((declared (var-declared-type var)))
+      (type= new-value declared) ;; TODO: use type= or remove
       (unless (more-or-equally-specific-type-p new-value declared)
         (error "The derived type of ~S, which is ~S, is incompatible ~
                 with its previously declared type ~S."

--- a/src/global-environment.lisp
+++ b/src/global-environment.lisp
@@ -64,13 +64,13 @@
 (defun (setf var-declared-type) (new-value var)
   (check-type new-value ty)
   (let ((info (var-info var)))
-    (let ((existing-declared-type (entry-declared-type info)))
-      (when (and existing-declared-type
-                 (not (type= existing-declared-type new-value)))
-        (style-warn "Overwriting declared type of ~S from ~A to ~A"
-                    var
-                    (unparse-type existing-declared-type)
-                    (unparse-type new-value))))
+    (alexandria:when-let ((existing-declared-type (entry-declared-type info)))
+      (if (type= existing-declared-type new-value)
+          (return-from var-declared-type var)
+          (style-warn "Overwriting declared type of ~S from ~A to ~A"
+                      var
+                      (unparse-type existing-declared-type)
+                      (unparse-type new-value))))
     (alexandria:when-let ((derived (var-derived-type var)))
       (unless (more-or-equally-specific-type-p derived new-value)
         (error "Cannot declare ~S as ~S because that is ~
@@ -87,13 +87,13 @@
 (defun (setf var-derived-type) (new-value var)
   (check-type new-value ty)
   (let ((info (var-info var)))
-    (let ((existing-derived-type (entry-derived-type info)))
-      (when (and existing-derived-type
-                 (not (type= existing-derived-type new-value)))
-        (style-warn "Overwriting derived type of ~S from ~A to ~A"
-                    var
-                    (unparse-type existing-derived-type)
-                    (unparse-type new-value))))
+    (alexandria:when-let ((existing-derived-type (entry-derived-type info)))
+      (if (type= existing-derived-type new-value)
+          (return-from var-derived-type var)
+          (style-warn "Overwriting derived type of ~S from ~A to ~A"
+                      var
+                      (unparse-type existing-derived-type)
+                      (unparse-type new-value))))
     (alexandria:when-let ((declared (var-declared-type var)))
       (unless (more-or-equally-specific-type-p new-value declared)
         (error "The derived type of ~S, which is ~S, is incompatible ~

--- a/src/global-environment.lisp
+++ b/src/global-environment.lisp
@@ -95,7 +95,6 @@
                     (unparse-type existing-derived-type)
                     (unparse-type new-value))))
     (alexandria:when-let ((declared (var-declared-type var)))
-      (type= new-value declared) ;; TODO: use type= or remove
       (unless (more-or-equally-specific-type-p new-value declared)
         (error "The derived type of ~S, which is ~S, is incompatible ~
                 with its previously declared type ~S."


### PR DESCRIPTION
This PR makes overriding a type with the same type not show a warning. It also adds the old and new types to the warning message.

~***Depends on #22***~