### PR TITLE
overhaul global state management

### DIFF
--- a/coalton.asd
+++ b/coalton.asd
@@ -27,6 +27,7 @@
                (:file "compile-value")
                (:file "toplevel-declare")
                (:file "toplevel-define-type")
+               (:file "global-lexical")
                (:file "toplevel-define")
                (:file "coalton")
                (:file "faux-macros")

--- a/src/global-environment.lisp
+++ b/src/global-environment.lisp
@@ -6,7 +6,6 @@
 
 (defstruct entry
   "An entry in the global value database."
-  (internal-name nil :type symbol)
   (declared-type nil :type (or null ty))
   (derived-type nil :type (or null ty))
   source-form
@@ -42,17 +41,13 @@
     (style-warn "Overwriting info entry for ~S" var))
   (setf (gethash var **global-value-definitions**) new-value))
 
-(defun make-internal-name (s)
-  (check-type s symbol)
-  (gentemp (symbol-name s) ':coalton-global-symbols))
-
 (defun forward-declare-variable (var &optional (declared-type nil declaredp))
   (check-type var symbol)
   (check-type declared-type (or ty null))
   (when (var-knownp var)
     (error "Can't forward declare ~S, which is already known." var))
   (setf (gethash var **global-value-definitions**)
-        (make-entry :internal-name (make-internal-name var)))
+        (make-entry))
   (when declaredp
     (setf (var-declared-type var) declared-type))
   var)

--- a/src/global-lexical.lisp
+++ b/src/global-lexical.lisp
@@ -1,0 +1,24 @@
+;;;; global-lexical.lisp
+
+(in-package #:coalton-impl)
+
+;;; Allow the definition of global lexical values in Common
+;;; Lisp. Based off of Ron Garret's GLOBALS.
+
+(define-symbol-property lexical-cell)
+
+(defun get-lexical-cell (symbol)
+  (or (lexical-cell symbol)
+      (setf (lexical-cell symbol)
+            ;; Intentionally obtuse name.
+            (intern (format nil "(lexical) ~A::~A" (package-name (symbol-package symbol)) symbol)
+                    '#:coalton-global-symbols))))
+
+(defmacro lexical-value (var)
+  `(symbol-value ',(get-lexical-cell var)))
+
+;;; TODO: Allow the type to be declared.
+(defmacro define-global-lexical (var val)
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
+     (setf (lexical-value ,var) ,val)
+     (define-symbol-macro ,var (lexical-value ,var))))

--- a/src/global-lexical.lisp
+++ b/src/global-lexical.lisp
@@ -11,7 +11,9 @@
   (or (lexical-cell symbol)
       (setf (lexical-cell symbol)
             ;; Intentionally obtuse name.
-            (intern (format nil "(lexical) ~A::~A" (package-name (symbol-package symbol)) symbol)
+            (intern (format nil "(lexical) ~A::~A"
+                            (package-name (symbol-package symbol))
+                            symbol)
                     '#:coalton-global-symbols))))
 
 (defmacro lexical-value (var)

--- a/src/toplevel-define.lisp
+++ b/src/toplevel-define.lisp
@@ -61,9 +61,8 @@
   (cond
     ((var-definedp name)
      ;; XXX: Get this right. Re-typecheck everything?!
-     (let ((internal-name (entry-internal-name (var-info name))))
-       (list
-        `(setf ,internal-name ,(compile-value-to-lisp expr)))))
+     (list
+      `(setf ,name ,(compile-value-to-lisp expr))))
     (t
      (unless (var-knownp name)
        ;; Declare the variable.
@@ -71,7 +70,7 @@
      ;; The type inferencing has already been done by this point. (See
      ;; `PROCESS-TOPLEVEL-VALUE-DEFINITIONS'.)
      (let (;;(inferred-type (node-derived-type expr))
-           (internal-name (entry-internal-name (var-info name))))
+           )
        ;; FIXME check VAR-DECLARED-TYPE
        ;; FIXME check VAR-DERIVED-TYPE
        (setf ;;(var-derived-type name)             inferred-type
@@ -79,13 +78,12 @@
        (when whole-provided-p
          (setf (entry-source-form (var-info name)) whole))
        (list*
-        `(define-symbol-macro ,name ,internal-name)
-        `(global-vars:define-global-var ,internal-name
+        `(define-global-lexical ,name
              ,(if (not self)
                   (compile-value-to-lisp expr)
                   `(let (,name)
-                    (setf ,name ,(compile-value-to-lisp expr))
-                    ,name)))
+                     (setf ,name ,(compile-value-to-lisp expr))
+                     ,name)))
         (when (eq ':function kind)
           (list
            `(defun ,name (,@args)

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -30,3 +30,19 @@
 
 (defun style-warn (format-control &rest format-args)
   (apply #'alexandria:simple-style-warning format-control format-args))
+
+(defmacro define-symbol-property (property-accessor &key
+                                                      (type nil type-provided)
+                                                      (documentation nil doc-provided))
+  ;; TODO document
+  ;;
+  ;; TODO use docs and type
+  (declare (ignore type type-provided documentation doc-provided))
+  (let ((symbol (gensym "SYMBOL"))
+        (new-value (gensym "NEW-VALUE")))
+    `(progn
+       (declaim (inline ,property-accessor (setf ,property-accessor)))
+       (defun ,property-accessor (,symbol)
+         (get ,symbol ',property-accessor))
+       (defun (setf ,property-accessor) (,new-value ,symbol)
+         (setf (get ,symbol ',property-accessor) ,new-value)))))


### PR DESCRIPTION
Global data is shoved into a hash table which doesn't survive fasls. We try to instead shove global data into the symbol namespace, namely the symbol's plist.